### PR TITLE
add env config support

### DIFF
--- a/genoci
+++ b/genoci
@@ -168,8 +168,7 @@ def process_annotations(OCI, tags, k):
         annotations = tags[k]["annotations"]
     except:
         return True
-    envs = [v for k, v in annotations.items()
-            if k == "env"]
+    envs = [d['env'] for d in annotations if 'env' in d]
     OCI.configs["environment"] = envs
     return True
 

--- a/genoci
+++ b/genoci
@@ -160,6 +160,19 @@ def process_cmds(OCI, tags, k):
     OCI.configs["entrypoint"] = shlex.split(runs)
     return True
 
+def process_annotations(OCI, tags, k):
+    """get environment keys out of annotations
+    currently ignores other annotations.
+    """
+    try:
+        annotations = tags[k]["annotations"]
+    except:
+        return True
+    envs = [v for k, v in annotations.items()
+            if k == "env"]
+    OCI.configs["environment"] = envs
+    return True
+
 def copy_file(OCI, pair):
     copy = pair.split()
     if len(copy) != 2:
@@ -335,6 +348,10 @@ while len(todo) != 0:
             sys.exit(1)
         if not process_cmds(OCI, tags, k):
             print("Failed setting entrypoint")
+            handle_pre_post(OCI, tags, k, "post")
+            sys.exit(1)
+        if not process_annotations(OCI, tags, k):
+            print("Failed setting annotations")
             handle_pre_post(OCI, tags, k, "post")
             sys.exit(1)
         handle_pre_post(OCI, tags, k, "post")

--- a/umoci.py
+++ b/umoci.py
@@ -18,6 +18,11 @@
 
 import datetime
 import os
+try:                            #py3
+      from shlex import quote
+except ImportError:             #py2
+      from pipes import quote
+
 import shutil
 import subprocess
 import sys
@@ -156,8 +161,9 @@ class Umoci:
 
         # set environment if in config
         if len(self.configs["environment"]) != 0:
+            envargs = ''
             for arg in self.configs["environment"]:
-                envargs = envargs + ' --config.env="' + arg + '"'
+                envargs = envargs + ' --config.env={}'.format(quote(arg))
             ret = os.system(cfgcmd + envargs)
             assert(0 == ret)
 

--- a/umoci.py
+++ b/umoci.py
@@ -82,7 +82,7 @@ class Umoci:
         del odir
 
     def clearconfig(self):
-        self.configs = { "entrypoint": [] }
+        self.configs = { "entrypoint": [], "environment": [] }
 
     def ListTags(self):
         odir = Chdir(self.parentdir)
@@ -145,12 +145,20 @@ class Umoci:
             assert(0 == os.system(cmd))
             del odir
 
+        cfgcmd = 'umoci config --image %s/%s:%s' % (self.parentdir, self.name, tag)
         # set the entrypoint if specified
         if len(self.configs["entrypoint"]) != 0:
-            cmd = 'umoci config --image %s/%s:%s' % (self.parentdir, self.name, tag)
+            epargs = ''
             for arg in self.configs["entrypoint"]:
-                cmd = cmd + ' --config.cmd="' + arg + '"'
-            ret = os.system(cmd)
+                epargs = epargs + ' --config.cmd="' + arg + '"'
+            ret = os.system(cfgcmd + epargs)
+            assert(0 == ret)
+
+        # set environment if in config
+        if len(self.configs["environment"]) != 0:
+            for arg in self.configs["environment"]:
+                envargs = envargs + ' --config.env="' + arg + '"'
+            ret = os.system(cfgcmd + envargs)
             assert(0 == ret)
 
     def AddTag(self, tag, newtag):


### PR DESCRIPTION
## Big picture
This is step 1 in specifying env vars in a genoci recipe and having them show up in the running lxc container at the other end of the masticator. Step 2 is having the `extract_oci` script look for these OCI config vars and use them as it feels appropriate.

## What it does though

Adds support in genoci for reading environment variables specified in a recipe YAML like this

```yaml
es:
  base: elasticsearch5
  entrypoint: /bin/bash bin/es-docker
  annotations:
    - env: cluster_name=docker-cluster
    - env: discovery_zen_ping_unicast_hosts=10.0.0.1,10.0.0.2,10.0.0.3
    - env: bootstrap_memory_lock=true
    - env: bootstrap_system_call_filter=false
    - env: ES_JAVA_OPTS="-Xms1g -Xmx1g"
```
and passing them through into the generated OCI image metadata, looking like this output from `umoci raw runtime-config --image oci:es /tmp/config.json`, run on an oci layout generated by running `genoci` on a recipe that included the snippet above...
```json
{
        "ociVersion": "1.0.0",
        "process": {
                "terminal": true,
                "user": {
                        "uid": 0,
                        "gid": 0
                },
                "args": [
                        "/bin/bash",
                        "bin/es-docker"
                ],
                "env": [
                        "PATH=/usr/share/elasticsearch/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                        "TERM=xterm",
                        "ELASTIC_CONTAINER=true",
                        "JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk",
                        "cluster_name=docker-cluster",
                        "discovery_zen_ping_unicast_hosts=10.0.0.1,10.0.0.2,10.0.0.3",
                        "bootstrap_memory_lock=true",
                        "bootstrap_system_call_filter=false",
                        "ES_JAVA_OPTS=\"-Xms1g -Xmx1g\""
                ],
...
```
etc…


