### PR TITLE
make sure shellscripts we write are -e

### DIFF
--- a/umoci.py
+++ b/umoci.py
@@ -217,7 +217,7 @@ class Umoci:
 
         fullname = self.chrootdir + "/ocirun"
         with open(fullname, "w") as outfile:
-            outfile.write("#/bin/sh\n")
+            outfile.write("#/bin/sh -e\n")
             outfile.write(data)
         cmd = "chmod ugo+x " + fullname
         os.system(cmd)


### PR DESCRIPTION
so we exit on failure

Reported-by: Andrei Aaron <andaaron@cisco.com>
Signed-off-by: Serge Hallyn <shallyn@cisco.com>